### PR TITLE
Security F1: require explicit DB passwords in compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,10 +7,12 @@
 #   4. Open http://localhost:8050 (or your LAN IP)
 
 # Database credentials (used by both docker-compose and backend)
-DB_ROOT_PASSWORD=changeme
+# DB_ROOT_PASSWORD and DB_PASSWORD are REQUIRED — compose refuses to start if unset.
+# Generate strong values with: openssl rand -base64 24
+DB_ROOT_PASSWORD=
 DB_NAME=HamLogDB
 DB_USER=hamlog
-DB_PASSWORD=changeme
+DB_PASSWORD=
 
 # Port the app is accessible on (default 8050)
 # Change this to run on a different port, e.g. PORT=3000

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,9 +1,11 @@
-# Database connection (matches docker-compose.yml defaults)
+# Database connection
+# DB_PASSWORD and DB_ROOT_PASSWORD are REQUIRED — compose refuses to start if unset.
+# Generate strong values with: openssl rand -base64 24
 DB_HOST=localhost
 DB_USER=hamlog
-DB_PASSWORD=hamlog_pw
+DB_PASSWORD=
 DB_NAME=HamLogDB
-DB_ROOT_PASSWORD=changeme
+DB_ROOT_PASSWORD=
 
 # Backend server port
 PORT=8050

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,10 +3,10 @@ services:
     image: mysql:8.0
     restart: unless-stopped
     environment:
-      MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD:-hamlog_root_pw}
+      MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD:?DB_ROOT_PASSWORD is required — generate with openssl rand -base64 24}
       MYSQL_DATABASE: ${DB_NAME:-HamLogDB}
       MYSQL_USER: ${DB_USER:-hamlog}
-      MYSQL_PASSWORD: ${DB_PASSWORD:-hamlog_pw}
+      MYSQL_PASSWORD: ${DB_PASSWORD:?DB_PASSWORD is required — generate with openssl rand -base64 24}
     volumes:
       - hamlog_data:/var/lib/mysql
       - ./backend/init-db:/docker-entrypoint-initdb.d
@@ -26,7 +26,7 @@ services:
       PORT: 8050
       DB_HOST: db
       DB_USER: ${DB_USER:-hamlog}
-      DB_PASSWORD: ${DB_PASSWORD:-hamlog_pw}
+      DB_PASSWORD: ${DB_PASSWORD:?DB_PASSWORD is required — generate with openssl rand -base64 24}
       DB_NAME: ${DB_NAME:-HamLogDB}
       JWT_SECRET: ${JWT_SECRET:?JWT_SECRET is required — generate with node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"}
       NODE_ENV: production


### PR DESCRIPTION
## Summary

Implements **finding F1** from `SECURITY_AUDIT.md` (Phase 1 of the phased security cleanup).

`docker-compose.yml` previously used `${VAR:-default}` fallbacks for the database
passwords, so if an operator never set `DB_PASSWORD` / `DB_ROOT_PASSWORD` the stack
silently booted with the **publicly-known repo defaults** (`hamlog_pw` /
`hamlog_root_pw`). This change makes those passwords **required**, using the same
`${VAR:?message}` form already used for `JWT_SECRET` in the same file — so Compose now
fails fast with a clear, actionable error instead of falling back to a weak default.

### Changes
- `docker-compose.yml`: `MYSQL_ROOT_PASSWORD`, `MYSQL_PASSWORD` (db service) and
  `DB_PASSWORD` (app service) switched from `:-default` to `:?required`, with an
  `openssl rand -base64 24` hint in the message.
- `.env.example` (root) and `backend/.env.example`: `DB_PASSWORD` / `DB_ROOT_PASSWORD`
  marked **REQUIRED** with a generation hint and blanked (no weak placeholder values);
  dropped the now-stale "matches docker-compose.yml defaults" comment.

Scope is **F1 only** — no application code and no other audit findings are touched.

## Verification

Docker is **not installed in the dev environment used here**, so a full
`docker compose config` / `up` could not be run locally. Compose variable
interpolation uses POSIX `${VAR:?err}` semantics, which were verified directly:

- ✅ **Fail-fast when unset** — running the same `:?` expansion the compose file uses
  with `DB_ROOT_PASSWORD` / `DB_PASSWORD` unset prints the actionable message to stderr
  and exits non-zero.
- ✅ **Resolves cleanly when set** — with both vars exported (throwaway values), the
  expansion succeeds (exit 0).
- ✅ **`docker-compose.yml` still parses as valid YAML** (PyYAML `safe_load`).
- ✅ **No stray `:-` password fallbacks remain** (grep of `docker-compose.yml`).
- ⚠️ **Backend test suite not run here** — `backend/node_modules` is not installed in
  this environment. This change is config-only (no `.ts`/`.js` touched) and cannot
  affect the suite; CI should still confirm it stays green.

**Please run on a machine with Docker before merging:**
```
docker compose config            # should error clearly if DB_PASSWORD/DB_ROOT_PASSWORD unset
DB_PASSWORD=… DB_ROOT_PASSWORD=… docker compose config   # should resolve cleanly
```

## ⚠️ Operator action (OB-1)

No secret was ever committed to git — `.env` is absent from the entire history — so
**no history rewrite/purge is needed.** However, if this deployment was ever started
**without** setting `DB_PASSWORD` / `DB_ROOT_PASSWORD`, the live MySQL has been running
on the publicly-known repo defaults. In that case, **rotate the MySQL root and app DB
passwords** when applying this change (set strong values in `.env` first).

Refs: `SECURITY_AUDIT.md` → F1, OB-1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)