### PR TITLE
Security F2: run container as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,5 @@ RUN npm ci --omit=dev && npm install tsx
 COPY backend/ .
 COPY --from=frontend /app/build ./public/
 EXPOSE 8050
+USER node
 CMD ["npx", "tsx", "src/server.ts"]


### PR DESCRIPTION
## Summary

Implements **finding F2** from `SECURITY_AUDIT.md` (Phase 2 of the phased security cleanup).

The production stage of `Dockerfile` had no `USER` directive, so the Node app ran as
**root** inside the container — a code-execution bug would have had root in the
container. This adds a single `USER node` directive (the unprivileged user the
`node:20-alpine` base image already ships) immediately before `CMD`, dropping
privileges for the running process.

### Why no `chown` / mount changes were needed
- Image files created by `npm ci` and `COPY` are world-readable, so `node` can read
  the app source + `node_modules` and execute `node_modules/.bin/tsx`. The runtime
  needs only read/execute, not write.
- The app **writes nothing to disk at runtime**: `multer` uses `memoryStorage`
  (`backend/src/routes/qsos.ts`), and the backup routes (`backend/src/routes/backup.ts`)
  stream over HTTP via `res.send(...)` rather than writing files. No `writeFile`/
  `createWriteStream`/`mkdir` exists anywhere in `backend/src`.
- `/home/node` exists and is writable by `node`, so `npx tsx` (which execs the
  locally-installed binary) won't hit EACCES.

Kept to a one-line diff per "minimal change — just the privilege drop".

## ⚠️ `./backups` mount consideration (please note)

The original task worried about a fixed `node` UID failing to write to the host-mounted
`./backups`. **This change does not affect backups**, because:
- In `docker-compose.yml` the **app service has no `volumes:` at all**. The
  `./backups:/backups` mount is on the **`db`** service (for the operator's
  `mysqldump`/restore against MySQL — see `scripts/backup.ps1`, CLAUDE.md). The MySQL
  container's user is unaffected by this Dockerfile.
- The app's own "backup" feature is an **HTTP download** (`GET /api/backup/json|adif`),
  not a disk write.

➡️ **Watch this only if** a writable bind mount is ever added to the *app* service in
future — at that point the mounted dir would need to be writable by the `node` UID
(prefer `chown` to the node UID on the host dir, **not** `chmod 777` and **not**
reverting to root).

## Verification

**Done in this environment:**
- ✅ Dockerfile is well-formed; `USER node` is placed after all root-time `COPY`/`RUN`
  steps and before `CMD`; no other line/stage touched (one-line diff).

**Docker is not installed in the dev environment used here**, so the image could not
be built or run locally — not faking a container run. **Please run on the Docker host / CI:**
```
docker compose build app
docker compose up -d
docker compose exec app id      # expect uid=1000(node) gid=1000(node), NOT root
# app reachable on :8050; exercise the backup download (HTTP, not disk):
curl -fsS -H "Authorization: Bearer <token>" http://localhost:8050/api/backup/json -o /tmp/b.json
```

**Backend test suite:** unaffected — no TS/JS changed (Dockerfile only). The suite
also can't run here (`backend/node_modules` not installed in this env); CI covers it.

Refs: `SECURITY_AUDIT.md` → F2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)