### PR TITLE
Security F3+F8: rate-limit auth endpoints and throttle HamDB lookup

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -13,6 +13,7 @@
         "cors": "^2.8.5",
         "dotenv": "^17.4.2",
         "express": "^4.22.2",
+        "express-rate-limit": "^8.5.2",
         "helmet": "^8.2.0",
         "jsonwebtoken": "^9.0.3",
         "multer": "^2.1.1",
@@ -3548,6 +3549,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -3947,6 +3966,15 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -19,6 +19,7 @@
     "cors": "^2.8.5",
     "dotenv": "^17.4.2",
     "express": "^4.22.2",
+    "express-rate-limit": "^8.5.2",
     "helmet": "^8.2.0",
     "jsonwebtoken": "^9.0.3",
     "multer": "^2.1.1",

--- a/backend/src/middleware/rate-limit.ts
+++ b/backend/src/middleware/rate-limit.ts
@@ -1,0 +1,36 @@
+import rateLimit, { Options } from 'express-rate-limit';
+import type { Request } from 'express';
+
+// Tunable limits (named constants so they are easy to adjust).
+export const AUTH_WINDOW_MS = 15 * 60 * 1000; // 15 minutes
+export const AUTH_MAX = 10; // F3: ~10 auth attempts / 15 min / IP
+export const LOOKUP_WINDOW_MS = 60 * 1000; // 1 minute
+export const LOOKUP_MAX = 20; // F8: polite HamDB cap / minute / user
+
+// 429 body matches the app's error shape ({ error }) from middleware/error-handler.ts.
+const TOO_MANY = { error: 'Too many requests, please try again later.' };
+
+function makeLimiter(opts: Partial<Options>) {
+  return rateLimit({
+    standardHeaders: true, // emit RateLimit-* headers
+    legacyHeaders: false, // no legacy X-RateLimit-* headers
+    message: TOO_MANY,
+    // Never throttle the test suite (characterization tests hammer the auth routes).
+    skip: () => process.env.NODE_ENV === 'test',
+    ...opts,
+  });
+}
+
+// F3 — auth endpoints. Keyed by IP (default keyGenerator). No trust proxy is set on
+// the app, so on a bare single-host Docker publish LAN clients may share one IP and
+// thus one bucket; that is acceptable for the LAN threat model (legit logins are rare,
+// 10/15min is generous, brute force is still bounded). See the PR for the tradeoff.
+export const authLimiter = makeLimiter({ windowMs: AUTH_WINDOW_MS, limit: AUTH_MAX });
+
+// F8 — manual HamDB lookup. Keyed per authenticated user (requireAuth runs first), so
+// it never collapses to a shared LAN IP and each user gets their own polite budget.
+export const lookupLimiter = makeLimiter({
+  windowMs: LOOKUP_WINDOW_MS,
+  limit: LOOKUP_MAX,
+  keyGenerator: (req: Request) => `user:${req.user?.userId ?? 'anon'}`,
+});

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -2,11 +2,12 @@ import { Router, Request, Response } from 'express';
 import { register, login, AuthError } from '../services/auth-service.js';
 import { registerSchema, loginSchema } from '../schemas/auth.schema.js';
 import { requireAuth } from '../middleware/auth.js';
+import { authLimiter } from '../middleware/rate-limit.js';
 import logger from '../logger.js';
 
 const router = Router();
 
-router.post('/register', async (req: Request, res: Response) => {
+router.post('/register', authLimiter, async (req: Request, res: Response) => {
   try {
     const input = registerSchema.parse(req.body);
     const result = await register(input);
@@ -25,7 +26,7 @@ router.post('/register', async (req: Request, res: Response) => {
   }
 });
 
-router.post('/login', async (req: Request, res: Response) => {
+router.post('/login', authLimiter, async (req: Request, res: Response) => {
   try {
     const input = loginSchema.parse(req.body);
     const result = await login(input);

--- a/backend/src/routes/contact-info.ts
+++ b/backend/src/routes/contact-info.ts
@@ -1,5 +1,6 @@
 import { Router, Request, Response, NextFunction } from 'express';
 import { requireAuth } from '../middleware/auth.js';
+import { lookupLimiter } from '../middleware/rate-limit.js';
 import { validate } from '../middleware/validate.js';
 import { createContactInfoSchema } from '../schemas/contact-info.schema.js';
 import {
@@ -40,7 +41,7 @@ router.post('/', requireAuth, validate(createContactInfoSchema), async (req: Req
   }
 });
 
-router.post('/lookup', requireAuth, async (req: Request, res: Response, next: NextFunction) => {
+router.post('/lookup', requireAuth, lookupLimiter, async (req: Request, res: Response, next: NextFunction) => {
   try {
     const callsign = req.body.callsign;
     if (!callsign || typeof callsign !== 'string') {


### PR DESCRIPTION
## Summary

Implements **findings F3 (rate-limit auth endpoints) and F8 (throttle the external
HamDB lookup)** from `SECURITY_AUDIT.md` (Phase 5), grouped because F8 reuses the
limiter utility introduced for F3. No `client/` changes; no `--force`.

## Shared limiter — `backend/src/middleware/rate-limit.ts`
A small factory over `express-rate-limit` with `standardHeaders: true`,
`legacyHeaders: false`, a JSON 429 body matching the app's `{ error }` shape, and
limits exposed as named constants. It is **skipped under `NODE_ENV=test`** so the
characterization suite (which drives the auth routes when a DB is present) can't hit
flaky 429s.

| Limiter | Endpoint(s) | Limit | Key |
|---|---|---|---|
| `authLimiter` (F3) | `POST /api/auth/login`, `POST /api/auth/register` | **10 / 15 min** | IP |
| `lookupLimiter` (F8) | `POST /api/contact-info/lookup` | **20 / min** | **authenticated user** |

- **F3** is the proportionate brute-force control per the audit — no account lockout,
  CAPTCHA, or password-complexity (explicitly ruled out for the LAN model). `/me` is
  not limited.
- **F8** is a *politeness* throttle for the free HamDB API (ADR 0001), so it uses a
  separate, more permissive limit tuned for interactive logging. `/backfill` is
  untouched (it already sleeps 500ms between calls).

## trust-proxy / `req.ip` decision (stated, not silent)
`app.ts` sets **no `trust proxy`**, and I left it that way: enabling it without a real
reverse proxy would trust a spoofable `X-Forwarded-For` and let an attacker bypass the
limiter.

- **Implication:** on a bare single-host Docker publish, LAN clients may all appear as
  the Docker gateway IP, so the **auth (F3) limiter can share one bucket** across the
  LAN. Acceptable for the threat model — legitimate logins are infrequent and 10/15min
  is generous, while sustained brute force is still bounded.
- **F8 is immune** — it keys by authenticated user, not IP, so each user gets their own
  budget regardless of source IP.
- **Follow-up (not in this PR):** if the app is fronted by a reverse proxy, set
  `app.set('trust proxy', 1)` for true per-client keying.

## Verification (run here)
- ✅ `npm test`: **45/45 passed**; `npm run typecheck` (`tsc --noEmit`): clean.
- ✅ **429 demonstrated via live curl** (booted with `NODE_ENV=development` so the
  limiter is active; mysql2 pool is lazy so the server listens without a DB):
  - 12× `POST /api/auth/login`: requests 1–10 pass through (HTTP 500 only because the
    DB is down — *not* rate-limited), requests **11–12 → HTTP 429**.
  - 429 response: body `{"error":"Too many requests, please try again later."}` with
    `RateLimit-Policy: 10;w=900`, `RateLimit-Limit: 10`, `RateLimit-Remaining: 0`,
    `Retry-After: 900`, and **no** legacy `X-RateLimit-*` headers.
  - `POST /api/contact-info/lookup` without a token → 401, confirming `requireAuth`
    runs before `lookupLimiter` (so it keys by user).

Refs: `SECURITY_AUDIT.md` → F3, F8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)