### PR TITLE
Security F7: validate /api/qsos/map query params

### DIFF
--- a/backend/__tests__/map-query-validation.test.ts
+++ b/backend/__tests__/map-query-validation.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from '@jest/globals';
+
+/**
+ * Unit tests for GET /api/qsos/map query validation (Security F7).
+ * Exercises validateQuery(mapQuerySchema) directly with mock req/res/next —
+ * no DB or running server needed.
+ */
+
+async function getValidator() {
+  const { validateQuery } = await import('../src/middleware/validate.js');
+  const { mapQuerySchema } = await import('../src/schemas/map.schema.js');
+  return validateQuery(mapQuerySchema);
+}
+
+function mockReq(query: Record<string, unknown>) {
+  return { query } as any;
+}
+
+function mockRes() {
+  const res: any = {};
+  res.status = (code: number) => { res.statusCode = code; return res; };
+  res.json = (body: any) => { res.body = body; return res; };
+  return res;
+}
+
+describe('validateQuery(mapQuerySchema) — /api/qsos/map', () => {
+  it('passes a valid from/to pair (calls next, no response)', async () => {
+    const mw = await getValidator();
+    const req = mockReq({ from: '2026-01-01', to: '2026-06-04' });
+    const res = mockRes();
+    let nextCalled = false;
+
+    mw(req, res, () => { nextCalled = true; });
+
+    expect(nextCalled).toBe(true);
+    expect(res.statusCode).toBeUndefined();
+  });
+
+  it('passes when both params are omitted', async () => {
+    const mw = await getValidator();
+    const req = mockReq({});
+    const res = mockRes();
+    let nextCalled = false;
+
+    mw(req, res, () => { nextCalled = true; });
+
+    expect(nextCalled).toBe(true);
+    expect(res.statusCode).toBeUndefined();
+  });
+
+  it('passes when params are empty strings (preserved no-filter behavior)', async () => {
+    const mw = await getValidator();
+    const req = mockReq({ from: '', to: '' });
+    const res = mockRes();
+    let nextCalled = false;
+
+    mw(req, res, () => { nextCalled = true; });
+
+    expect(nextCalled).toBe(true);
+    expect(res.statusCode).toBeUndefined();
+  });
+
+  it('passes when only one param is provided', async () => {
+    const mw = await getValidator();
+    const req = mockReq({ from: '2026-01-01' });
+    const res = mockRes();
+    let nextCalled = false;
+
+    mw(req, res, () => { nextCalled = true; });
+
+    expect(nextCalled).toBe(true);
+    expect(res.statusCode).toBeUndefined();
+  });
+
+  it('rejects a non-date string with 400 and the app error shape', async () => {
+    const mw = await getValidator();
+    const req = mockReq({ from: 'notadate' });
+    const res = mockRes();
+    let nextCalled = false;
+
+    mw(req, res, () => { nextCalled = true; });
+
+    expect(nextCalled).toBe(false);
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toHaveProperty('error', 'Validation failed');
+    expect(Array.isArray(res.body.details)).toBe(true);
+    expect(res.body.details[0].field).toBe('from');
+  });
+
+  it('rejects an out-of-range date (2026-13-40) with 400', async () => {
+    const mw = await getValidator();
+    const req = mockReq({ to: '2026-13-40' });
+    const res = mockRes();
+    let nextCalled = false;
+
+    mw(req, res, () => { nextCalled = true; });
+
+    expect(nextCalled).toBe(false);
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toBe('Validation failed');
+  });
+});

--- a/backend/src/middleware/validate.ts
+++ b/backend/src/middleware/validate.ts
@@ -22,3 +22,28 @@ export function validate(schema: ZodSchema) {
     }
   };
 }
+
+// Like validate(), but for req.query. It validates for rejection only and does NOT
+// reassign req.query (which is a read-only getter in newer Express); the handler keeps
+// reading the now-known-valid req.query. Returns the same 400 shape as validate().
+export function validateQuery(schema: ZodSchema) {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    try {
+      schema.parse(req.query);
+      next();
+    } catch (err) {
+      if (err instanceof ZodError) {
+        const issues = err.issues ?? [];
+        res.status(400).json({
+          error: 'Validation failed',
+          details: issues.map((e) => ({
+            field: String(e.path?.join('.') ?? ''),
+            message: e.message,
+          })),
+        });
+        return;
+      }
+      next(err);
+    }
+  };
+}

--- a/backend/src/routes/qsos.ts
+++ b/backend/src/routes/qsos.ts
@@ -1,8 +1,9 @@
 import { Router, Request, Response, NextFunction } from 'express';
 import multer from 'multer';
 import { requireAuth } from '../middleware/auth.js';
-import { validate } from '../middleware/validate.js';
+import { validate, validateQuery } from '../middleware/validate.js';
 import { createQsoSchema, createPotaQsoSchema, createContestQsoSchema } from '../schemas/qso.schema.js';
+import { mapQuerySchema } from '../schemas/map.schema.js';
 import {
   createContact, createPotaQso, createContestQso,
   deleteContact, getAllQsosWithPota,
@@ -69,7 +70,7 @@ router.post('/import', requireAuth, upload.single('file'), async (req: Request, 
   }
 });
 
-router.get('/map', requireAuth, async (req: Request, res: Response, next: NextFunction) => {
+router.get('/map', requireAuth, validateQuery(mapQuerySchema), async (req: Request, res: Response, next: NextFunction) => {
   try {
     const from = typeof req.query.from === 'string' ? req.query.from : undefined;
     const to = typeof req.query.to === 'string' ? req.query.to : undefined;

--- a/backend/src/schemas/map.schema.ts
+++ b/backend/src/schemas/map.schema.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+// Query params for GET /api/qsos/map. Both optional ISO YYYY-MM-DD strings; '' is
+// allowed and treated as "no filter", preserving prior behavior for ?from= / ?to=.
+export const mapQuerySchema = z.object({
+  from: z.union([z.iso.date(), z.literal('')]).optional(),
+  to: z.union([z.iso.date(), z.literal('')]).optional(),
+});
+
+export type MapQuery = z.infer<typeof mapQuerySchema>;


### PR DESCRIPTION
## Summary

Implements **finding F7** from `SECURITY_AUDIT.md` (Phase 6) and **closes the item
carried over from `docs/wip/session-handoff.md`** ("Zod validation for `GET
/api/qsos/map` query params"). No `client/` changes, no dependency changes, no SQL
changes.

This is **correctness hardening, not a vulnerability fix.** `from`/`to` already flow
into **parameterized** queries (no SQL injection — confirmed-good in the audit).
Previously a malformed date silently produced odd/empty results; now it's rejected at
the route boundary with a clean 400.

## Changes
- **`backend/src/schemas/map.schema.ts`** (new) — `from`/`to` as optional ISO
  `YYYY-MM-DD` strings (`z.iso.date()`, Zod 4). `''` is explicitly allowed and treated
  as "no filter", preserving today's behavior for `?from=`/`?to=`.
- **`backend/src/middleware/validate.ts`** — new `validateQuery()` sibling of
  `validate()`. **It validates `req.query` for rejection only and does NOT reassign
  `req.query`** — `req.query` is a read-only getter in newer Express, and the handler
  already reads `req.query.from`/`to` directly, so reassignment is both unsafe and
  unnecessary. Returns the same 400 shape as `validate()`.
- **`backend/src/routes/qsos.ts`** — wired `validateQuery(mapQuerySchema)` onto
  `GET /api/qsos/map` after `requireAuth`. **Handler body unchanged.**
- **`backend/__tests__/map-query-validation.test.ts`** (new) — 6 cases.

## Behavior preserved
Valid pair, single param, omitted, and empty-string (`?from=`) all still pass through
to the handler exactly as before. **Only genuinely malformed dates now 400.**

## Verification (run here — pure TS)
- ✅ `npm run typecheck` (`tsc --noEmit`): clean.
- ✅ `npm test`: **51/51 passed** (45 prior + 6 new map-validation cases).
- ✅ Live `curl` (server booted; validation runs after `requireAuth`, before any DB call):
  - `?from=notadate` → **400** `{"error":"Validation failed","details":[{"field":"from","message":"Invalid ISO date"}]}`
  - `?to=2026-13-40` → **400**
  - `?from=2026-01-01` (valid) → passes validation, then **500** only because the dev DB is down — i.e. valid dates flow through unchanged, not blocked
  - no token → **401** (requireAuth first)

Refs: `SECURITY_AUDIT.md` → F7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)