### PR TITLE
Data-quality F9: light field-format validation (callsign/freq/grid)

### DIFF
--- a/backend/__tests__/characterization.test.js
+++ b/backend/__tests__/characterization.test.js
@@ -376,14 +376,18 @@ describe('Multi-user data isolation', () => {
 });
 
 describe('SQL injection prevention', () => {
-  it('callsign with SQL injection is safely handled', async () => {
+  // Probe a free-form field (notes) rather than callsign: callsign now has light
+  // format validation (Data-quality F9) and would 400 an injection-shaped value, so
+  // notes is the right field to prove parameterization stores hostile input verbatim.
+  it('injection string in a free-form field is safely handled', async () => {
     if (skipIfNoDb()) return;
+    const injection = "';DROP TABLE Contacts;--";
     const res = await post('/qsos', {
       date: '01/01/2025',
       time: '12:00',
-      callsign: "';DROP T--",
+      callsign: 'W1SQL',
       frequency: '14.074',
-      notes: '',
+      notes: injection,
       received: '',
       sent: '',
     });
@@ -391,7 +395,7 @@ describe('SQL injection prevention', () => {
     const id = (await res.json()).id;
 
     const [rows] = await dbPool.execute('SELECT * FROM Contacts WHERE QSO_ID = ?', [id]);
-    expect(rows[0].QSO_Callsign).toBe("';DROP T--");
+    expect(rows[0].QSO_Notes).toBe(injection);
 
     await del(`/qsos/${id}`);
   });

--- a/backend/__tests__/field-formats.test.ts
+++ b/backend/__tests__/field-formats.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  normalizeCallsign,
+  isValidCallsign,
+  isValidFrequency,
+  isValidGrid,
+} from '../src/schemas/field-formats.js';
+
+/**
+ * Data-quality F9 — shared field-format validators. Lean-permissive: accept
+ * weird-but-legit, reject only obvious garbage.
+ */
+
+describe('isValidCallsign / normalizeCallsign', () => {
+  it.each([
+    'W1AW',          // bare call
+    'W1AW/3',        // portable suffix
+    'PA/W1AW/P',     // prefix/call/suffix
+    'VP2E/AE9S/MM',  // multiple segments
+    'ISOLATED',      // all letters, no digit
+  ])('accepts %s', (call) => {
+    expect(isValidCallsign(call)).toBe(true);
+  });
+
+  it('normalizes lowercase to uppercase and accepts it', () => {
+    expect(normalizeCallsign(' w1aw ')).toBe('W1AW');
+    expect(isValidCallsign('w1aw')).toBe(true);
+  });
+
+  it.each([
+    '',           // empty
+    '   ',        // whitespace only
+    'W1 AW',      // internal space
+    'W1@W',       // illegal char
+    "';DROP",     // injection-shaped garbage
+    '/W1AW',      // leading slash (empty segment)
+    'W1AW/',      // trailing slash (empty segment)
+  ])('rejects %s', (call) => {
+    expect(isValidCallsign(call)).toBe(false);
+  });
+});
+
+describe('isValidFrequency', () => {
+  it.each([
+    '14.074',    // HF
+    '0.1357',    // 2200m LF
+    '50',        // 6m
+    '1296',      // 23cm microwave
+    '1296.0',
+    '10368.1',   // 3cm microwave
+  ])('accepts %s MHz', (f) => {
+    expect(isValidFrequency(f)).toBe(true);
+  });
+
+  it.each([
+    '0',
+    '-5',
+    'abc',
+    '',
+  ])('rejects %s', (f) => {
+    expect(isValidFrequency(f)).toBe(false);
+  });
+});
+
+describe('isValidGrid', () => {
+  it.each([
+    '',          // absent — valid
+    'DN70',      // 4-char square
+    'DM79',
+    'FN31pr',    // 6-char subsquare, mixed case
+    'AA00',
+    'FN31pr00',  // 8-char extended
+  ])('accepts %s', (g) => {
+    expect(isValidGrid(g)).toBe(true);
+  });
+
+  it.each([
+    'ZZ99',   // Z is outside the A-R field range
+    'A',      // too short
+    '123',    // not a locator
+    'FN3',    // odd length
+  ])('rejects %s', (g) => {
+    expect(isValidGrid(g)).toBe(false);
+  });
+});

--- a/backend/__tests__/import-adif.test.ts
+++ b/backend/__tests__/import-adif.test.ts
@@ -1,0 +1,64 @@
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+
+/**
+ * Data-quality F9 — importAdif skip-and-report. A single bad record must NOT abort the
+ * batch; valid records import and bad ones are reported with a reason.
+ *
+ * Native-ESM Jest: the db pool is mocked so createContact/createPotaQso don't open a
+ * real connection (mysql.createPool runs at import time). Every db.execute resolves to
+ * an insert result, so each valid record "inserts" successfully.
+ */
+
+jest.unstable_mockModule('../src/db/pool.js', () => ({
+  default: {},
+  db: { execute: jest.fn() },
+}));
+
+const { importAdif } = await import('../src/services/qso-service.js');
+const { db } = await import('../src/db/pool.js');
+const mockExecute = db.execute as unknown as jest.Mock;
+
+describe('importAdif', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockExecute.mockResolvedValue([{ insertId: 1 }, []]);
+  });
+
+  it('imports valid records and skips-and-reports the bad ones (never throws)', async () => {
+    const records = [
+      { call: 'W1AW', qso_date: '20260101', time_on: '1200', freq: '14.074' }, // ok
+      { call: 'W1 AW', qso_date: '20260101', freq: '14.074' },                 // bad callsign
+      { call: 'N0CALL', qso_date: '20260101', freq: '0' },                     // bad frequency
+      { call: 'K1ABC', qso_date: '20260101' },                                 // ok, band-only (no freq)
+      { qso_date: '20260101' },                                                // missing callsign
+    ];
+
+    const result = await importAdif(records, 1);
+
+    expect(result.importedIds).toHaveLength(2);
+    expect(result.skipped).toHaveLength(3);
+
+    const reasons = result.skipped.map((s) => s.reason);
+    expect(reasons).toContain('invalid callsign format');
+    expect(reasons).toContain('invalid frequency');
+    expect(reasons).toContain('missing callsign');
+  });
+
+  it('does not abort the batch when one insert throws', async () => {
+    // First insert rejects, subsequent inserts succeed.
+    mockExecute
+      .mockRejectedValueOnce(new Error('db blip'))
+      .mockResolvedValue([{ insertId: 2 }, []]);
+
+    const records = [
+      { call: 'W1AW', qso_date: '20260101', freq: '14.074' }, // insert throws -> skipped
+      { call: 'K1ABC', qso_date: '20260101', freq: '7.040' }, // imported
+    ];
+
+    const result = await importAdif(records, 1);
+
+    expect(result.importedIds).toHaveLength(1);
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0].reason).toBe('insert failed');
+  });
+});

--- a/backend/src/routes/qsos.ts
+++ b/backend/src/routes/qsos.ts
@@ -9,8 +9,9 @@ import {
   deleteContact, getAllQsosWithPota,
   getQsosByCallsign, getQsosByPark, getQsosForExport,
   getQsosForMap, getQsoCountForRange, verifyContactOwnership,
+  importAdif,
 } from '../services/qso-service.js';
-import { parseAdif, adifRecordToQso } from '../services/adif-parser.js';
+import { parseAdif } from '../services/adif-parser.js';
 import { exportAdif } from '../services/adif-exporter.js';
 
 const router = Router();
@@ -40,31 +41,14 @@ router.post('/import', requireAuth, upload.single('file'), async (req: Request, 
     const content = req.file.buffer.toString('utf-8');
     const records = parseAdif(content);
 
-    const imported: number[] = [];
-    for (const record of records) {
-      const qso = adifRecordToQso(record);
-      if (!qso.callsign || !qso.date) continue;
+    const { importedIds, skipped } = await importAdif(records, userId);
 
-      const id = await createContact({
-        date: qso.date,
-        time: qso.time,
-        callsign: qso.callsign,
-        frequency: qso.frequency,
-        notes: qso.notes,
-        received: qso.received,
-        sent: qso.sent,
-        mode: qso.mode,
-        band: qso.band,
-      }, userId);
-
-      if (qso.potaParkId) {
-        await createPotaQso(String(id), qso.potaParkId, qso.potaQsoType || '1');
-      }
-
-      imported.push(id);
-    }
-
-    res.status(201).json({ imported: imported.length, ids: imported });
+    res.status(201).json({
+      imported: importedIds.length,
+      ids: importedIds,
+      skipped: skipped.length,
+      skippedRecords: skipped,
+    });
   } catch (err) {
     next(err);
   }

--- a/backend/src/schemas/contact-info.schema.ts
+++ b/backend/src/schemas/contact-info.schema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { gridField } from './field-formats.js';
 
 export const createContactInfoSchema = z.object({
   callsign: z.string().min(1, 'callsign is required'),
@@ -10,7 +11,7 @@ export const createContactInfoSchema = z.object({
   latitude: z.string().default(''),
   longitude: z.string().default(''),
   itu: z.string().default(''),
-  grid: z.string().default(''),
+  grid: gridField(),
   qth: z.string().default(''),
   country: z.string().default(''),
 });

--- a/backend/src/schemas/field-formats.ts
+++ b/backend/src/schemas/field-formats.ts
@@ -1,0 +1,59 @@
+import { z } from 'zod';
+
+/**
+ * Shared, lean-permissive field-format validators for callsign / frequency / grid
+ * (Data-quality F9). These catch obvious garbage, not style violations — when unsure,
+ * accept. Defined once and reused by the QSO create schema, the ADIF import path, and
+ * the ContactInfo schema. They do NOT provide any security property (injection is
+ * already prevented by parameterized queries).
+ */
+
+// --- Callsign ---------------------------------------------------------------
+// One or more slash-separated alphanumeric segments: bare calls (W1AW), with a
+// suffix (W1AW/3), and full prefix/call/suffix forms (PA/W1AW/P, VP2E/AE9S/MM).
+// Operators may type lowercase, so normalize to uppercase rather than rejecting.
+// Digits may appear anywhere and a digit is NOT required (e.g. special-event calls).
+const CALLSIGN_RE = /^[A-Z0-9]+(?:\/[A-Z0-9]+)*$/;
+
+export function normalizeCallsign(raw: string): string {
+  return raw.trim().toUpperCase();
+}
+
+export function isValidCallsign(raw: string): boolean {
+  return CALLSIGN_RE.test(normalizeCallsign(raw));
+}
+
+// --- Frequency (MHz) --------------------------------------------------------
+// Reject NaN / 0 / negative / nonsense, but accept the full amateur range from LF
+// (~0.1357 MHz) through microwave/SHF (23cm 1296 MHz and up past 241 GHz). The
+// ceiling is a generous sanity bound, not a band limit.
+const MAX_FREQ_MHZ = 300000; // ~300 GHz — above the highest amateur allocation
+
+export function isValidFrequency(raw: string): boolean {
+  const f = parseFloat(String(raw).trim());
+  return Number.isFinite(f) && f > 0 && f <= MAX_FREQ_MHZ;
+}
+
+// --- Maidenhead grid (optional) --------------------------------------------
+// 2/4/6/8 characters: field(AA) [square(00)] [subsquare(aa)] [extended(00)],
+// case-insensitive. Empty/absent is valid (many QSOs have no grid).
+const GRID_RE = /^[A-R]{2}(?:[0-9]{2}(?:[A-X]{2}(?:[0-9]{2})?)?)?$/i;
+
+export function isValidGrid(raw: string): boolean {
+  const g = String(raw).trim();
+  if (g === '') return true;
+  return GRID_RE.test(g);
+}
+
+// --- Zod field builders -----------------------------------------------------
+export const callsignField = () =>
+  z
+    .string()
+    .min(1, 'callsign is required')
+    .transform(normalizeCallsign)
+    .refine(isValidCallsign, 'Invalid callsign format');
+
+export const frequencyField = () =>
+  z.string().min(1, 'frequency is required').refine(isValidFrequency, 'Invalid frequency');
+
+export const gridField = () => z.string().default('').refine(isValidGrid, 'Invalid Maidenhead grid');

--- a/backend/src/schemas/qso.schema.ts
+++ b/backend/src/schemas/qso.schema.ts
@@ -1,10 +1,11 @@
 import { z } from 'zod';
+import { callsignField, frequencyField } from './field-formats.js';
 
 export const createQsoSchema = z.object({
   date: z.string().min(1, 'date is required'),
   time: z.string().default(''),
-  callsign: z.string().min(1, 'callsign is required'),
-  frequency: z.string().min(1, 'frequency is required'),
+  callsign: callsignField(),
+  frequency: frequencyField(),
   notes: z.string().default(''),
   received: z.string().default(''),
   sent: z.string().default(''),

--- a/backend/src/services/qso-service.ts
+++ b/backend/src/services/qso-service.ts
@@ -1,6 +1,8 @@
 import { ResultSetHeader, RowDataPacket } from 'mysql2';
 import { db } from '../db/pool.js';
 import type { CreateQsoInput } from '../schemas/qso.schema.js';
+import { isValidCallsign, isValidFrequency, normalizeCallsign } from '../schemas/field-formats.js';
+import { adifRecordToQso, type AdifRecord } from './adif-parser.js';
 import { lookupAndCreateContactInfo } from './contact-info-service.js';
 import logger from '../logger.js';
 
@@ -24,6 +26,69 @@ export async function createContact(input: CreateQsoInput, userId: number): Prom
   );
 
   return result.insertId;
+}
+
+export interface ImportSkip {
+  callsign: string;
+  reason: string;
+}
+
+export interface ImportResult {
+  importedIds: number[];
+  skipped: ImportSkip[];
+}
+
+/**
+ * Import a batch of parsed ADIF records (Data-quality F9). Each record is validated
+ * independently and a single bad record is SKIPPED-AND-REPORTED, never aborting the
+ * whole batch — important when re-importing large or third-party logs. Lean-permissive:
+ * empty frequency is allowed (band-only QSOs); only present-but-garbage is rejected.
+ */
+export async function importAdif(records: AdifRecord[], userId: number): Promise<ImportResult> {
+  const importedIds: number[] = [];
+  const skipped: ImportSkip[] = [];
+
+  for (const record of records) {
+    const qso = adifRecordToQso(record);
+    const rawCall = qso.callsign;
+
+    if (!rawCall || !qso.date) {
+      skipped.push({ callsign: rawCall || '(none)', reason: !rawCall ? 'missing callsign' : 'missing date' });
+      continue;
+    }
+    if (!isValidCallsign(rawCall)) {
+      skipped.push({ callsign: rawCall, reason: 'invalid callsign format' });
+      continue;
+    }
+    if (qso.frequency && !isValidFrequency(qso.frequency)) {
+      skipped.push({ callsign: rawCall, reason: 'invalid frequency' });
+      continue;
+    }
+
+    try {
+      const id = await createContact({
+        date: qso.date,
+        time: qso.time,
+        callsign: normalizeCallsign(rawCall),
+        frequency: qso.frequency,
+        notes: qso.notes,
+        received: qso.received,
+        sent: qso.sent,
+        mode: qso.mode,
+        band: qso.band,
+      }, userId);
+
+      if (qso.potaParkId) {
+        await createPotaQso(String(id), qso.potaParkId, qso.potaQsoType || '1');
+      }
+      importedIds.push(id);
+    } catch (err) {
+      logger.warn({ err, callsign: rawCall }, 'ADIF import: record failed, skipping');
+      skipped.push({ callsign: rawCall, reason: 'insert failed' });
+    }
+  }
+
+  return { importedIds, skipped };
 }
 
 export async function verifyContactOwnership(qsoId: string, userId: number): Promise<boolean> {


### PR DESCRIPTION
## Summary

Implements **finding F9** from `SECURITY_AUDIT.md`. **This is data-quality polish, NOT
security** — injection is already prevented by parameterized queries (confirmed-good in
the audit). Previously `callsign`/`frequency` were `z.string().min(1)` and ADIF import
only checked non-empty callsign/date, so obvious garbage could be stored. F9 adds
**lean-permissive** format checks (catch clear garbage; when unsure, accept).

## Corrected two ham-domain errors in the audit's suggested rules
- **Frequency:** the audit suggested `0 < f < 1000 MHz`, which would **wrongly reject
  amateur microwave** (23cm = 1296 MHz, up through 241 GHz). Bound is now
  `0 < f <= 300000` MHz (~300 GHz) — rejects NaN/0/negative/nonsense, not real bands.
- **Callsign:** the audit regex allowed only **one** slash and uppercase-only. Real
  calls have multiple segments (`PA/W1AW/P`, `VP2E/AE9S/MM`) and may be typed
  lowercase. Now: one-or-more slash-separated alphanumeric segments, **normalized to
  uppercase** (not rejected), no digit required.

## Shared validators — `backend/src/schemas/field-formats.ts` (defined once)
`isValidCallsign`/`normalizeCallsign`, `isValidFrequency`, `isValidGrid`, plus Zod
field builders. Applied to:
- `createQsoSchema` → `callsign`, `frequency` (QSO create).
- ADIF import path (callsign + frequency).
- `createContactInfoSchema` → `grid`. **Grid only exists on ContactInfo** —
  `adifRecordToQso` drops `gridsquare` and `createContact` stores no grid, so grid is
  validated where it actually lives. HamDB-sourced grids bypass the schema (external
  data is never rejected).

## ADIF import: skip-and-report (the real design decision)
Extracted the import loop into a testable `importAdif(records, userId)` in
`qso-service.ts` (matches the "logic in services/" convention). Each record is
validated independently and **a single bad record is skipped-and-reported, never
aborting the batch** — important for re-importing large or third-party logs (contest
logs, other loggers). A per-record `try/catch` means one insert error skips only that
record. **Lean-permissive:** empty frequency is allowed (band-only QSOs); only
present-but-garbage is rejected.

The `/import` response gains **backward-compatible** fields — `imported` + `ids`
unchanged, plus `skipped` (count) and `skippedRecords` (`[{callsign, reason}]`).

## SQL-injection characterization test
That test posted callsign `';DROP T--` expecting 201; with callsign format validation
it would now correctly 400. Moved the injection probe to the **free-form `notes`
field** (asserts it's stored verbatim) so the parameterization proof stays intact.

## Verification (run here)
- ✅ `tsc --noEmit` clean.
- ✅ `npm test`: **86/86 passed** (new `field-formats` + `import-adif` suites; import
  test proves one bad record is skipped+reported while the rest import, and that an
  insert error doesn't abort the batch).
- ✅ Live `curl` (create path validates before the DB call):
  - garbage callsign `w1 aw` → **400** `{"error":"Validation failed","details":[{"field":"callsign","message":"Invalid callsign format"}]}`
  - frequency `0` → **400** (field `frequency`)
  - lowercase `w1aw` → passes (normalized), microwave `1296` MHz → passes — both only 500 because the dev DB is down, i.e. **accepted, not rejected**.

Refs: `SECURITY_AUDIT.md` → F9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)