### PR TITLE
Data-quality F10: cap ADIF import record count

### DIFF
--- a/backend/__tests__/import-adif.test.ts
+++ b/backend/__tests__/import-adif.test.ts
@@ -1,4 +1,4 @@
-import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
 
 /**
  * Data-quality F9 — importAdif skip-and-report. A single bad record must NOT abort the
@@ -14,7 +14,7 @@ jest.unstable_mockModule('../src/db/pool.js', () => ({
   db: { execute: jest.fn() },
 }));
 
-const { importAdif } = await import('../src/services/qso-service.js');
+const { importAdif, ImportLimitError } = await import('../src/services/qso-service.js');
 const { db } = await import('../src/db/pool.js');
 const mockExecute = db.execute as unknown as jest.Mock;
 
@@ -22,6 +22,10 @@ describe('importAdif', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockExecute.mockResolvedValue([{ insertId: 1 }, []]);
+  });
+
+  afterEach(() => {
+    delete process.env.MAX_IMPORT_RECORDS; // never leak the cap override between tests
   });
 
   it('imports valid records and skips-and-reports the bad ones (never throws)', async () => {
@@ -60,5 +64,34 @@ describe('importAdif', () => {
     expect(result.importedIds).toHaveLength(1);
     expect(result.skipped).toHaveLength(1);
     expect(result.skipped[0].reason).toBe('insert failed');
+  });
+
+  describe('record cap (F10)', () => {
+    it('rejects an over-cap file before any insert (zero rows written)', async () => {
+      process.env.MAX_IMPORT_RECORDS = '2';
+      const records = [
+        { call: 'W1AW', qso_date: '20260101', freq: '14.074' },
+        { call: 'K1ABC', qso_date: '20260101', freq: '7.040' },
+        { call: 'N1XYZ', qso_date: '20260101', freq: '21.0' },
+      ];
+
+      await expect(importAdif(records, 1)).rejects.toThrow(ImportLimitError);
+      await expect(importAdif(records, 1)).rejects.toThrow(/exceeding the import limit of 2/);
+      expect(mockExecute).not.toHaveBeenCalled(); // rejected before the insert loop
+    });
+
+    it('accepts a file at the cap and F9 skip-and-report still applies', async () => {
+      process.env.MAX_IMPORT_RECORDS = '2';
+      const records = [
+        { call: 'W1AW', qso_date: '20260101', freq: '14.074' }, // ok
+        { call: 'W1 AW', qso_date: '20260101', freq: '14.074' }, // bad callsign -> skipped
+      ];
+
+      const result = await importAdif(records, 1);
+
+      expect(result.importedIds).toHaveLength(1);
+      expect(result.skipped).toHaveLength(1);
+      expect(result.skipped[0].reason).toBe('invalid callsign format');
+    });
   });
 });

--- a/backend/src/routes/qsos.ts
+++ b/backend/src/routes/qsos.ts
@@ -9,7 +9,7 @@ import {
   deleteContact, getAllQsosWithPota,
   getQsosByCallsign, getQsosByPark, getQsosForExport,
   getQsosForMap, getQsoCountForRange, verifyContactOwnership,
-  importAdif,
+  importAdif, ImportLimitError,
 } from '../services/qso-service.js';
 import { parseAdif } from '../services/adif-parser.js';
 import { exportAdif } from '../services/adif-exporter.js';
@@ -50,6 +50,10 @@ router.post('/import', requireAuth, upload.single('file'), async (req: Request, 
       skippedRecords: skipped,
     });
   } catch (err) {
+    if (err instanceof ImportLimitError) {
+      res.status(400).json({ error: err.message });
+      return;
+    }
     next(err);
   }
 });

--- a/backend/src/services/qso-service.ts
+++ b/backend/src/services/qso-service.ts
@@ -38,13 +38,36 @@ export interface ImportResult {
   skipped: ImportSkip[];
 }
 
+// Whole-file cap on the number of records per ADIF import (Data-quality F10). Tunable;
+// overridable via MAX_IMPORT_RECORDS for tests/ops. Not memory protection (the 10 MB
+// multer limit already bounds input) — it gives an early, clear rejection instead of a
+// confusing slow failure on an absurdly large file.
+export const MAX_IMPORT_RECORDS = 50000;
+
+export class ImportLimitError extends Error {
+  constructor(public readonly count: number, public readonly limit: number) {
+    super(
+      `ADIF file has ${count} records, exceeding the import limit of ${limit}. ` +
+        `Split it into smaller files and import them separately.`,
+    );
+    this.name = 'ImportLimitError';
+  }
+}
+
 /**
  * Import a batch of parsed ADIF records (Data-quality F9). Each record is validated
  * independently and a single bad record is SKIPPED-AND-REPORTED, never aborting the
  * whole batch — important when re-importing large or third-party logs. Lean-permissive:
  * empty frequency is allowed (band-only QSOs); only present-but-garbage is rejected.
+ *
+ * F10: an over-cap file is rejected up front (before any insert) rather than truncated.
  */
 export async function importAdif(records: AdifRecord[], userId: number): Promise<ImportResult> {
+  const limit = Number(process.env.MAX_IMPORT_RECORDS) || MAX_IMPORT_RECORDS;
+  if (records.length > limit) {
+    throw new ImportLimitError(records.length, limit);
+  }
+
   const importedIds: number[] = [];
   const skipped: ImportSkip[] = [];
 


### PR DESCRIPTION
## Summary

Implements **finding F10** from `SECURITY_AUDIT.md` — the **final item in the
remediation plan**. **Data-quality, not security.** The 10 MB multer file-size limit
already bounds input and the parser is injection-safe, so this isn't memory protection
— it's an **early, clear rejection** instead of a confusing slow failure or a partial
insert of an enormous batch.

## Change
- **`MAX_IMPORT_RECORDS = 50000`** — a tunable named constant in `qso-service.ts`,
  overridable via the `MAX_IMPORT_RECORDS` env var (same mechanism style as F3/F8).
- **`ImportLimitError`** typed error (mirrors the `AuthError` service→route pattern).
- **Whole-file gate at the top of `importAdif`, before the insert loop**, on the
  TOTAL parsed record count: `if (records.length > limit) throw new ImportLimitError(...)`.
  At-limit is allowed (`>`), so the cap is inclusive.
- **`routes/qsos.ts`** maps `ImportLimitError` → **400** with a clear message naming the
  count and the limit.

### Reject, don't truncate
An over-cap file is rejected up front and **writes zero rows** — no silent "imported
the first N, dropped the rest". The accepted (under-cap) response is unchanged.

### Composes cleanly with F9
The cap counts **total** records and runs as a gate independent of F9's per-record
skip-and-report — no double-counting, and F9's behavior/summary for accepted files is
untouched.

## Verification (run here — pure TS)
- ✅ `tsc --noEmit` clean.
- ✅ `npm test`: **88/88 passed**. New cap cases (cap lowered to 2 via the env override
  so no 50k fixture is needed):
  - over-cap (3 records) → rejects with `ImportLimitError` / `…exceeding the import
    limit of 2`, **and `db.execute` is never called** (zero rows, rejected before any insert).
  - at-cap (2 records, one bad callsign) → resolves; imports 1, reports 1 skip — proving
    the gate composes with F9.
- ✅ Live `curl` (booted with `MAX_IMPORT_RECORDS=1`, a 2-record ADIF, no DB needed
  since the throw precedes any insert):
  `{"error":"ADIF file has 2 records, exceeding the import limit of 1. Split it into smaller files and import them separately."}` → **HTTP 400**.

This is the last remediation-plan item; with it, every finding F1–F10 from the audit is
addressed.

Refs: `SECURITY_AUDIT.md` → F10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)